### PR TITLE
Update JRE versions from v121 to v211

### DIFF
--- a/recipes-devtools/oracle-java/oracle-jse-ejre-arm-sflt-client-headless.inc
+++ b/recipes-devtools/oracle-java/oracle-jse-ejre-arm-sflt-client-headless.inc
@@ -1,5 +1,5 @@
 PV_UPDATE = "211"
-BUILD_NUMBER = "13"
+BUILD_NUMBER = "12"
 LICENSE_DIR = "ejdk${PV}_${PV_UPDATE}/linux_arm_sflt/jre"
 
 require oracle-jse-ejre.inc

--- a/recipes-devtools/oracle-java/oracle-jse-ejre-arm-sflt-client-headless.inc
+++ b/recipes-devtools/oracle-java/oracle-jse-ejre-arm-sflt-client-headless.inc
@@ -1,4 +1,4 @@
-PV_UPDATE = "121"
+PV_UPDATE = "211"
 BUILD_NUMBER = "13"
 LICENSE_DIR = "ejdk${PV}_${PV_UPDATE}/linux_arm_sflt/jre"
 
@@ -6,5 +6,5 @@ require oracle-jse-ejre.inc
 
 SRC_URI = "http://nvs0336/os-resources/oracle/ejdk-8u${PV_UPDATE}-linux-arm-sflt.tar.gz"
 
-SRC_URI[md5sum] = "11041e7eedd897d70cabe54f29d10587"
-SRC_URI[sha256sum] = "9ad72839dba09e336954c7653778a2517e6d0e56a9524f4c11ff008ad3eb4637"
+SRC_URI[md5sum] = "22d3b9513918b76ac00e9053f8b5963f"
+SRC_URI[sha256sum] = "d6b35496bd29e08cb73eadbfef7e026ac9713c1f6a1f0907d1e35dff21e7b6b2"

--- a/recipes-devtools/oracle-java/oracle-jse-ejre.inc
+++ b/recipes-devtools/oracle-java/oracle-jse-ejre.inc
@@ -14,8 +14,8 @@ require oracle-jse.inc
 DEPENDS = "virtual/java-native"
 
 LIC_FILES_CHKSUM = "\
-	file://${LICENSE_DIR}/COPYRIGHT;md5=3dc1bfbd5bed75d650ad0506a0df5930 \
-	file://${LICENSE_DIR}/THIRDPARTYLICENSEREADME.txt;md5=745d6db5fc58c63f74ce6a7d4db7e695 \
+	file://${LICENSE_DIR}/COPYRIGHT;md5=a762796b2a8989b8952b653a178607a1 \
+	file://${LICENSE_DIR}/THIRDPARTYLICENSEREADME.txt;md5=6965eeef8a55556bb1dded43bca822dd \
 	"
 
 do_compile() {


### PR DESCRIPTION
Update Oracle Java Runtime (JRE) from v121b13 to v211b12,
which is the latest freely available JRE distributed by Oracle by
this date.